### PR TITLE
Fix npe when building and analyzing larger projects

### DIFF
--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/kotlinModelUtils.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/kotlinModelUtils.kt
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.jobs.JobChangeAdapter
 import org.eclipse.jdt.core.IJavaProject
 import org.jetbrains.kotlin.core.KotlinClasspathContainer
 import org.jetbrains.kotlin.core.utils.ProjectUtils
+import org.eclipse.core.resources.ResourcesPlugin
 
 fun unconfigureKotlinProject(javaProject: IJavaProject) {
     val project = javaProject.getProject()
@@ -95,6 +96,7 @@ fun runJob(
     }
     
     job.setPriority(priority)
+    job.setRule(ResourcesPlugin.getWorkspace().getRoot());
     
     job.addJobChangeListener(object : JobChangeAdapter() {
         override fun done(event: IJobChangeEvent) {

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaElementUtil.java
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaElementUtil.java
@@ -116,6 +116,9 @@ public class EclipseJavaElementUtil {
     private static ITypeBinding getJavaLangObjectBinding(@NotNull IJavaProject javaProject) {
         try {
             IType javaType = javaProject.findType(CommonClassNames.JAVA_LANG_OBJECT);
+            if(javaType == null) {
+            	return null; // this happens if the project was modified while analyzing in progress.
+            }
             return EclipseJavaClassFinder.createTypeBinding(javaType);
         } catch (JavaModelException e) {
             KotlinLogger.logAndThrow(e);

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/builder/KotlinAnalysisJob.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/builder/KotlinAnalysisJob.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlin.core.model.KotlinAnalysisProjectCache
 import org.jetbrains.kotlin.progress.CompilationCanceledException
 import org.jetbrains.kotlin.progress.CompilationCanceledStatus
 import org.jetbrains.kotlin.progress.ProgressIndicatorAndCompilationCanceledStatus
+import org.eclipse.core.resources.ResourcesPlugin
 
 public class KotlinAnalysisJob(private val javaProject: IJavaProject) : Job("Kotlin Analysis") {
     init {
@@ -86,6 +87,7 @@ fun runCancellableAnalysisFor(javaProject: IJavaProject, postAnalysisTask: (Anal
     KotlinAnalysisProjectCache.resetCache(javaProject.project)
     
     val analysisJob = KotlinAnalysisJob(javaProject)
+    analysisJob.setRule(ResourcesPlugin.getWorkspace().getRoot());
     
     analysisJob.addJobChangeListener(object : JobChangeAdapter() {
         override fun done(event: IJobChangeEvent) {


### PR DESCRIPTION
Introduce scheduling rules to make sure different jobs are executed without conflicting each other using the workspace as the scheduling rule.